### PR TITLE
Add password hashing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ python3 -m http.server 8080
 ```
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+## 🔒 Password Hashing
+
+User passwords are now hashed using **bcrypt** via `passlib`. You can tune the
+hashing complexity by setting the optional `BCRYPT_ROUNDS` environment variable
+when running the backend. The default is `12` rounds.

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -4,13 +4,14 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models, schemas
+from app.utils import hash_password
 
 
 async def create_user(db: AsyncSession, user: schemas.UserCreate) -> models.User:
     db_user = models.User(
         name=user.name,
         email=user.email,
-        hashed_password=user.password,
+        hashed_password=hash_password(user.password),
         latitude=user.latitude,
         longitude=user.longitude,
         skills=user.skills,

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,20 @@
+import os
+from passlib.context import CryptContext
+
+bcrypt_rounds = int(os.getenv("BCRYPT_ROUNDS", 12))
+
+pwd_context = CryptContext(
+    schemes=["bcrypt"],
+    deprecated="auto",
+    bcrypt__rounds=bcrypt_rounds,
+)
+
+
+def hash_password(password: str) -> str:
+    """Return a bcrypt hashed password."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against the hashed version."""
+    return pwd_context.verify(plain_password, hashed_password)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ asyncpg
 psycopg2-binary
 pydantic
 python-multipart
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- hash user passwords using passlib's bcrypt implementation
- add optional `BCRYPT_ROUNDS` environment variable
- document password hashing in README
- install `passlib[bcrypt]`

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68402ba7a6648323b83328631ddbe7be