### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Rescue-Net-eu/Rescue-Net.eu/security/code-scanning/1](https://github.com/Rescue-Net-eu/Rescue-Net.eu/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily checks out the repository and runs Docker commands, which only require `contents: read` permissions. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
