### PR TITLE
Fix Gradle wrapper version

### DIFF
--- a/mobile/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.4-bin.zip


### PR DESCRIPTION
## Summary
- provide a Gradle wrapper properties file for the mobile project
- use version 8.1.4 to avoid the typo `8.14`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68402e85e96083238e0f2b5d6e68f02a