### PR TITLE
Configure dependabot for backend and mobile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/backend"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/mobile"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- specify `pip` updates for the backend
- enable `gradle` updates for the mobile Android project

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68402e8727a083239fde564f572687cf