### PR TITLE
Fix user retrieval route to accept UUID

### DIFF
--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import UUID
 
 from app import crud, schemas
 from app.database import get_db
@@ -14,7 +15,8 @@ async def register_user(user: schemas.UserCreate, db: AsyncSession = Depends(get
 
 
 @router.get("/{user_id}", response_model=schemas.UserOut)
-async def get_user(user_id: str, db: AsyncSession = Depends(get_db)):
+async def get_user(user_id: UUID, db: AsyncSession = Depends(get_db)):
+    """Retrieve a user by UUID."""
     user = await crud.get_user(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")


### PR DESCRIPTION
## Summary
- ensure `/users/{user_id}` parses the path parameter as a UUID
- add a brief docstring for the route

## Testing
- `python -m py_compile backend/app/*.py backend/app/routes/*.py backend/app/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68403018218c83238c1129b7846dc8af