### PR TITLE
Add Docker Compose setup for full stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 npm-debug.log*
 .env
+!apps/api/.env
+!apps/web/.env
 .DS_Store
 
 # Turborepo

--- a/README.md
+++ b/README.md
@@ -77,3 +77,41 @@ Note:
 - All UI text (e.g., “Create Alert” / “Creează Alertă”, “Subscribe to Alert” / “Abonează-te la Alertă”, etc.) is managed via JSON files in `public/locales/{lang}/common.json` (web) and `src/locales/{lang}/common.json` (mobile).
 - The previous code, which did not implement membership endpoints or password-based authentication and lacked alert flow, has been fully replaced.
 - Ensure each file generated strictly follows this specification, including i18n and Transifex integration.
+
+## Running with Docker Compose
+
+1. Build and start all services (Postgres, API, Web):
+   ```bash
+   docker-compose up --build
+   ```
+
+2. Apply Prisma migrations inside the API container:
+
+   ```bash
+   docker-compose exec api npx prisma migrate dev --name init
+   ```
+
+   (Or use `npx prisma migrate deploy` in production.)
+
+Visit the web app at http://localhost:3001. The Next.js frontend automatically calls the API at http://api:3000 inside Docker.
+
+The API is available at http://localhost:3000. You can test the health endpoint:
+
+```bash
+curl http://localhost:3000/health
+```
+
+To stop and remove containers:
+
+```bash
+docker-compose down
+```
+
+If you need to reset the database data:
+
+```bash
+docker-compose down -v
+rm -rf postgres-data
+docker-compose up --build
+docker-compose exec api npx prisma migrate dev --name init
+```

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://postgres:postgres@db:5432/rescue_net
+JWT_SECRET=your_jwt_secret_here
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=your_smtp_password
+INVITE_BASE_URL=http://web:3000/signup

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,29 @@
+# ------------------------------
+# Stage 1: Build
+# ------------------------------
+FROM node:18-alpine AS builder
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ------------------------------
+# Stage 2: Production image
+# ------------------------------
+FROM node:18-alpine AS runner
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/package*.json ./
+RUN npm ci --only=production
+
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/prisma ./prisma
+COPY --from=builder /usr/src/app/.env .env
+
+EXPOSE 3000
+ENV NODE_ENV=production
+
+CMD ["node", "dist/main.js"]

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './prisma.module';
 import { InvitationsModule } from './invitations/invitations.module';
@@ -21,5 +22,6 @@ import { PasswordResetModule } from './password-reset/password-reset.module';
     AlertsModule,
     PasswordResetModule,
   ],
+  controllers: [HealthController],
 })
 export class AppModule {}

--- a/apps/api/src/health.controller.ts
+++ b/apps/api/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  health() {
+    return { status: 'ok' };
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
-  await app.listen(process.env.PORT || 3000);
+  await app.listen(process.env.PORT || 3000, '0.0.0.0');
 }
 bootstrap();

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://api:3000

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,31 @@
+# ------------------------------
+# Stage 1: Build
+# ------------------------------
+FROM node:18-alpine AS builder
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ------------------------------
+# Stage 2: Production image
+# ------------------------------
+FROM node:18-alpine AS runner
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/package*.json ./
+RUN npm ci --only=production
+
+COPY --from=builder /usr/src/app/.next ./.next
+COPY --from=builder /usr/src/app/public ./public
+COPY --from=builder /usr/src/app/next.config.js ./next.config.js
+COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY --from=builder /usr/src/app/.env .env
+
+EXPOSE 3000
+ENV NODE_ENV=production
+
+CMD ["npm", "start", "--", "-H", "0.0.0.0", "-p", "3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: rescue-net-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: rescue_net
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+      target: runner
+    container_name: rescue-net-api
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ./apps/api/.env
+    ports:
+      - '3000:3000'
+    networks:
+      - default
+
+  web:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile
+      target: runner
+    container_name: rescue-net-web
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_started
+    env_file:
+      - ./apps/web/.env
+    ports:
+      - '3001:3000'
+    networks:
+      - default
+
+volumes:
+  postgres-data:
+
+networks:
+  default:
+    name: rescue-net-network
+    driver: bridge


### PR DESCRIPTION
## Summary
- create Docker Compose config for Postgres, API and Web
- add environment files for API and Web
- add two-stage Dockerfiles for API and Web
- expose NestJS on 0.0.0.0 and add a health endpoint
- document Docker usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684092ad8ec48323a9bcd5aeb69b1157