### PR TITLE
Fix missing permissions for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- limit GitHub token permissions for CodeQL analysis workflow

## Testing
- `npm run lint` *(fails: turbo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8ca73908323a08cc0bbdb1f90d9