### PR TITLE
Fix CodeQL languages configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,6 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ["javascript", "typescript"]
-          # Skip Python entirely
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- remove obsolete python comment in CodeQL workflow
- ensure workflow only lists JavaScript/TypeScript languages

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab6dfae48323a6381e4f84955906