### PR TITLE
Add CI workflow for tests and docker build

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,21 @@
+name: Test and Build Docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Run tests
+        run: npm test
+      - name: Build Docker image
+        run: docker-compose build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "lint": "turbo run lint"
+    "lint": "turbo run lint",
+    "test": "turbo run lint"
   },
   "devDependencies": {
     "turbo": "^1.5.3"


### PR DESCRIPTION
## Summary
- add `test` script in package.json to run lint across packages
- create a `ci-docker.yml` workflow to run tests and build the docker images

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c6aee36c8323a6a989596257a241