### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wf-ci-docker.yml
+++ b/.github/workflows/wf-ci-docker.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Rescue-Net-eu/Rescue-Net.eu/security/code-scanning/4](https://github.com/Rescue-Net-eu/Rescue-Net.eu/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level (root) to limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's steps, it only needs to read the repository contents (e.g., to check out the code). Therefore, we will set `contents: read` as the minimal required permission. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
