### PR TITLE
Fix docker compose environment section

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
         condition: service_healthy
     env_file:
       - ./.env
-    environment:
-      # You can override or inject here, but env_file is enough.
     volumes:
       - api-uploads:/app/uploads
     ports:


### PR DESCRIPTION
## Summary
- remove unused environment block from `services.api` in docker-compose.yml

## Testing
- `npm test` *(fails: `turbo` not found)*
- `npm install` *(fails to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_6840e97204088323aedf40d7bb7d4584