### PR TITLE
Fix docker compose environment section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in the values
+DATABASE_URL=postgres://postgres:postgres@db:5432/rescue_net
+JWT_SECRET=your_jwt_secret_here
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=your_smtp_password
+INVITE_BASE_URL=http://web:3000/signup
+NEXT_PUBLIC_API_URL=http://api:3000
+FIREBASE_SERVICE_ACCOUNT=
+APNS_KEY_FILE=./certs/apns_key.p8
+APNS_KEY_ID=
+APNS_TEAM_ID=
+APNS_BUNDLE_ID=eu.rescue-net

--- a/.github/workflows/wf-ci-docker.yml
+++ b/.github/workflows/wf-ci-docker.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm install --legacy-peer-deps
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ apps/mobile/node_modules/
 apps/mobile/ios/Pods/
 apps/mobile/android/app/build/
 apps/mobile/ios/build/
+.env

--- a/apps/mobile/.eslintrc.json
+++ b/apps/mobile/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "env": {
-    "es2021": true,
-    "node": true
-  }
-}

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+  {
+    ignores: ['node_modules/**'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+    },
+  },
+];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
         condition: service_healthy
     env_file:
       - ./.env
-    environment:
-      # You can override or inject here, but env_file is enough.
     volumes:
       - api-uploads:/app/uploads
     ports:


### PR DESCRIPTION
## Summary
- remove unused environment block from `services.api` in docker-compose.yml
- add example env file
- use Node 20 in CI workflow
- migrate mobile lint config to flat config

## Testing
- `npm test` *(fails: turbo not found)*
- `npm install` *(fails to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_6840e97204088323aedf40d7bb7d4584