### PR TITLE
Use flat config for mobile lint

### DIFF
--- a/apps/mobile/.eslintrc.json
+++ b/apps/mobile/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "env": {
-    "es2021": true,
-    "node": true
-  }
-}

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,0 +1,21 @@
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default compat.config({
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  env: {
+    es2021: true,
+    node: true,
+  },
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.11",


### PR DESCRIPTION
## Summary
- convert mobile ESLint config to flat format
- run eslint via simple command

## Testing
- `npm test` *(fails: Error while loading rule '@typescript-eslint/no-empty-function')*

------
https://chatgpt.com/codex/tasks/task_e_6840e9733ad083238e4922599e53e2f9