### PR TITLE
Add API helper to web app

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'next-i18next';
+import api from '../../utils/api';
 
 type Mission = {
   id: string;
@@ -26,7 +27,7 @@ export default function DashboardPage() {
 
   const fetchMissions = async () => {
     setLoadingMissions(true);
-    const res = await fetch('/api/missions', {
+    const res = await api('/api/missions', {
       headers: { Authorization: `Bearer ${document.cookie.replace('token=', '')}` },
     });
     const data = await res.json();
@@ -35,7 +36,7 @@ export default function DashboardPage() {
   };
 
   const subscribeToMission = async (missionId: string) => {
-    await fetch(`/api/missions/${missionId}/assign/${localStorage.getItem('userId')}`, {
+    await api(`/api/missions/${missionId}/assign/${localStorage.getItem('userId')}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${document.cookie.replace('token=', '')}` },
     });
@@ -44,7 +45,7 @@ export default function DashboardPage() {
 
   const fetchAlerts = async () => {
     setLoadingAlerts(true);
-    const res = await fetch('/api/alerts?scope=local', {
+    const res = await api('/api/alerts?scope=local', {
       headers: { Authorization: `Bearer ${document.cookie.replace('token=', '')}` },
     });
     const data = await res.json();
@@ -53,7 +54,7 @@ export default function DashboardPage() {
   };
 
   const subscribeToAlert = async (alertId: string) => {
-    await fetch(`/api/alerts/${alertId}/subscribe/${localStorage.getItem('userId')}`, {
+    await api(`/api/alerts/${alertId}/subscribe/${localStorage.getItem('userId')}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${document.cookie.replace('token=', '')}` },
     });

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = 'force-dynamic';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
+import api from '../../utils/api';
 
 type FormData = {
   email: string;
@@ -16,7 +17,7 @@ export default function LoginPage() {
   const { register, handleSubmit, formState: { errors } } = useForm<FormData>();
 
   const onSubmit = async (data: FormData) => {
-    const res = await fetch('/api/auth/login', {
+    const res = await api('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/apps/web/src/utils/api.ts
+++ b/apps/web/src/utils/api.ts
@@ -1,0 +1,5 @@
+export default function api(path: string, options?: RequestInit) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
+  const url = `${baseUrl}${path}`;
+  return fetch(url, options);
+}


### PR DESCRIPTION
## Summary
- add `api` helper for client-side API requests
- refactor login page to use new helper
- refactor dashboard page to use new helper

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f08764d48323a96e597ec5ac597c