### PR TITLE
Decode JWT sub on login

### DIFF
--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -23,8 +23,9 @@ export default function LoginScreen() {
     });
     if (res.ok) {
       const { access_token } = await res.json();
+      const payload = JSON.parse(atob(access_token.split('.')[1]));
       await AsyncStorage.setItem('token', access_token);
-      await AsyncStorage.setItem('userId', access_token.split('.')[1]);
+      await AsyncStorage.setItem('userId', payload.sub);
 
       const perm = await request(
         Platform.OS === 'ios'

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -23,7 +23,9 @@ export default function LoginPage() {
     });
     if (res.ok) {
       const { access_token } = await res.json();
-      document.cookie = `token=${access_token}; path=/; HttpOnly`;
+      const payload = JSON.parse(atob(access_token.split('.')[1]));
+      localStorage.setItem('userId', payload.sub);
+      document.cookie = `token=${access_token}; path=/`;
       router.push('/dashboard');
     } else {
       alert(t('login.error_invalid'));


### PR DESCRIPTION
## Summary
- decode JWT access token to store userId on login
- drop invalid HttpOnly flag from client cookie

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0877d5c8323a717d457c34c9fe7