### PR TITLE
Make membership orgId optional

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -45,8 +45,8 @@ model Membership {
   id            String      @id @default(uuid())
   user          User        @relation(fields: [userId], references: [id])
   userId        String      @db.Uuid
-  organization  Organization @relation(fields: [orgId], references: [id])
-  orgId         String      @db.Uuid
+  organization  Organization? @relation(fields: [orgId], references: [id])
+  orgId         String?     @db.Uuid
   role          Role
   activeByOrg   Boolean     @default(true)
   activeByUser  Boolean     @default(true)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -102,7 +102,6 @@ export class AuthService {
     await this.prisma.membership.create({
       data: {
         userId: user.id,
-        orgId: '',
         role: 'VOLUNTEER',
         activeByOrg: false,
         activeByUser: true,

--- a/apps/api/src/memberships/dto/create-membership.dto.ts
+++ b/apps/api/src/memberships/dto/create-membership.dto.ts
@@ -5,8 +5,9 @@ export class CreateMembershipDto {
   @IsUUID()
   userId: string;
 
+  @IsOptional()
   @IsUUID()
-  orgId: string;
+  orgId?: string;
 
   @IsEnum(Role)
   role: Role;

--- a/apps/api/src/memberships/memberships.service.ts
+++ b/apps/api/src/memberships/memberships.service.ts
@@ -17,7 +17,7 @@ export class MembershipsService {
     return this.prisma.membership.create({
       data: {
         userId: dto.userId,
-        orgId: dto.orgId,
+        ...(dto.orgId ? { orgId: dto.orgId } : {}),
         role: dto.role,
         activeByOrg: dto.activeByOrg ?? false,
         activeByUser: dto.activeByUser ?? true,


### PR DESCRIPTION
## Summary
- make `orgId` optional in `Membership` schema
- adjust `CreateMembershipDto` validation
- allow optional `orgId` in `MembershipsService`
- omit `orgId` when creating membership in `signupDirect`
- run `npx prisma generate`

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f087189083239cb0ceda04d57c19