### PR TITLE
Add web environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
         condition: service_started
     env_file:
       - ./.env
+    environment:
+      - NEXT_PUBLIC_API_URL=http://api:3000
+      - NEXT_PUBLIC_VAPID_KEY=${NEXT_PUBLIC_VAPID_KEY}
     ports:
       - '3001:3000'
     networks:


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_VAPID_KEY` environment variables under the `web` service in `docker-compose.yml`
- confirm port mappings and volumes remain consistent

## Testing
- `npm test` *(fails: turbo not found / install issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840f47e01c88323825b9ab658b538df