### PR TITLE
Update alert image validation and storage

### DIFF
--- a/apps/api/src/alerts/alerts.controller.ts
+++ b/apps/api/src/alerts/alerts.controller.ts
@@ -23,17 +23,6 @@ import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { BadRequestException } from '@nestjs/common';
 import { Express } from 'express';
 
-const fileFilter = (req: any, file: Express.Multer.File, cb: Function) => {
-  const allowedMimes = ['image/jpeg', 'image/png', 'image/gif'];
-  if (!allowedMimes.includes(file.mimetype)) {
-    return cb(
-      new BadRequestException('Invalid file type. Only JPEG, PNG, and GIF are allowed.'),
-      false,
-    );
-  }
-  cb(null, true);
-};
-
 @Controller('alerts')
 export class AlertsController {
   constructor(private readonly alertsService: AlertsService) {}
@@ -42,7 +31,16 @@ export class AlertsController {
   @Roles(Role.PLATFORM_ADMIN, Role.GOV_OPERATOR, Role.INST_OPERATOR, Role.ORG_OPERATOR, Role.ERCC_OPERATOR)
   @UseInterceptors(
     FileFieldsInterceptor([{ name: 'images', maxCount: 5 }], {
-      fileFilter,
+      fileFilter: (req, file, cb) => {
+        const allowedMimes = ['image/jpeg', 'image/png', 'image/webp'];
+        if (!allowedMimes.includes(file.mimetype)) {
+          return cb(
+            new BadRequestException('Only JPEG, PNG, or WEBP images are allowed'),
+            false,
+          );
+        }
+        cb(null, true);
+      },
       limits: { fileSize: 5 * 1024 * 1024 },
     }),
   )

--- a/apps/api/src/alerts/alerts.service.ts
+++ b/apps/api/src/alerts/alerts.service.ts
@@ -4,6 +4,7 @@ import { PushService } from '../push/push.service';
 import { CreateAlertDto } from './dto/create-alert.dto';
 import { UpdateAlertStatusDto } from './dto/update-alert-status.dto';
 import { Express } from 'express';
+import * as path from 'path';
 
 @Injectable()
 export class AlertsService {
@@ -30,14 +31,17 @@ export class AlertsService {
     });
 
     if (files && files.length > 0) {
-      const createImages = files.map((file) =>
-        this.prisma.alertImage.create({
+      const createImages = files.map((file) => {
+        const safeName = path
+          .basename(file.originalname)
+          .replace(/[^a-zA-Z0-9._-]/g, '_');
+        return this.prisma.alertImage.create({
           data: {
             alertId: alert.id,
-            url: `uploads/alerts/${file.filename}`,
+            url: `uploads/alerts/${safeName}`,
           },
-        })
-      );
+        });
+      });
       await Promise.all(createImages);
     }
 


### PR DESCRIPTION
## Summary
- enforce JPEG/PNG/WEBP validation in `alerts.controller`
- sanitize filenames before persisting image records

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f47e74a88323af0ce0e26f1aeb44