### PR TITLE
Add global search and mission chat

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,10 @@
     "class-validator": "^0.14.0",
     "uuid": "^11.1.0",
     "firebase-admin": "^11.10.1",
-    "apn": "^2.2.0"
+    "apn": "^2.2.0",
+    "@nestjs/websockets": "^11.0.0",
+    "@nestjs/platform-socket.io": "^11.0.0",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { MissionsModule } from './missions/missions.module';
 import { AlertsModule } from './alerts/alerts.module';
 import { PasswordResetModule } from './password-reset/password-reset.module';
 import { PushModule } from './push/push.module';
+import { SearchModule } from './search/search.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { PushModule } from './push/push.module';
     AlertsModule,
     PasswordResetModule,
     PushModule,
+    SearchModule,
   ],
   controllers: [HealthController],
 })

--- a/apps/api/src/missions/mission.gateway.ts
+++ b/apps/api/src/missions/mission.gateway.ts
@@ -1,0 +1,24 @@
+import { WebSocketGateway, WebSocketServer, SubscribeMessage, MessageBody, ConnectedSocket } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+@WebSocketGateway({ namespace: 'missions' })
+export class MissionGateway {
+  @WebSocketServer()
+  server: Server;
+
+  @SubscribeMessage('join')
+  handleJoin(@MessageBody() missionId: string, @ConnectedSocket() socket: Socket) {
+    socket.join(missionId);
+    this.server.to(missionId).emit('joined', socket.id);
+  }
+
+  @SubscribeMessage('message')
+  handleMessage(
+    @MessageBody() data: { missionId: string; message: string; user: string },
+  ) {
+    this.server.to(data.missionId).emit('message', {
+      user: data.user,
+      message: data.message,
+    });
+  }
+}

--- a/apps/api/src/missions/missions.module.ts
+++ b/apps/api/src/missions/missions.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { MissionsService } from './missions.service';
 import { MissionsController } from './missions.controller';
 import { PrismaModule } from '../prisma.module';
+import { MissionGateway } from './mission.gateway';
 
 @Module({
   imports: [PrismaModule],
-  providers: [MissionsService],
+  providers: [MissionsService, MissionGateway],
   controllers: [MissionsController],
 })
 export class MissionsModule {}

--- a/apps/api/src/search/search.controller.ts
+++ b/apps/api/src/search/search.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '@prisma/client';
+
+@Controller('search')
+export class SearchController {
+  constructor(private readonly searchService: SearchService) {}
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    Role.PLATFORM_ADMIN,
+    Role.GOV_OPERATOR,
+    Role.INST_OPERATOR,
+    Role.ORG_OPERATOR,
+    Role.ERCC_OPERATOR,
+    Role.VOLUNTEER,
+  )
+  @Get()
+  search(@Query('q') query: string) {
+    return this.searchService.search(query);
+  }
+}

--- a/apps/api/src/search/search.module.ts
+++ b/apps/api/src/search/search.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { SearchController } from './search.controller';
+import { PrismaModule } from '../prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [SearchService],
+  controllers: [SearchController],
+})
+export class SearchModule {}

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class SearchService {
+  constructor(private prisma: PrismaService) {}
+
+  async search(query: string) {
+    const alerts = await this.prisma.alert.findMany({
+      where: {
+        OR: [
+          { title: { contains: query, mode: 'insensitive' } },
+          { description: { contains: query, mode: 'insensitive' } },
+        ],
+      },
+      include: { images: true },
+    });
+
+    const missions = await this.prisma.mission.findMany({
+      where: {
+        OR: [
+          { title: { contains: query, mode: 'insensitive' } },
+          { description: { contains: query, mode: 'insensitive' } },
+        ],
+      },
+    });
+
+    const volunteers = await this.prisma.user.findMany({
+      where: {
+        userType: 'VOLUNTEER',
+        OR: [
+          { firstName: { contains: query, mode: 'insensitive' } },
+          { lastName: { contains: query, mode: 'insensitive' } },
+          { email: { contains: query, mode: 'insensitive' } },
+        ],
+      },
+      select: { id: true, firstName: true, lastName: true, email: true },
+    });
+
+    return { alerts, missions, volunteers };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "react-dom": "18.2.0",
     "next-i18next": "^15.0.0",
     "dotenv": "^16.4.1",
-    "react-hook-form": "^7.50.0"
+    "react-hook-form": "^7.50.0",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/apps/web/src/components/layout/GlobalSearchOverlay.jsx
+++ b/apps/web/src/components/layout/GlobalSearchOverlay.jsx
@@ -1,9 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
+import api from '../../utils/api';
 
-export default function GlobalSearchOverlay() {
+export default function GlobalSearchOverlay({ isOpen, onClose }) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState(null);
+
+  if (!isOpen) return null;
+
+  const handleSearch = async () => {
+    const res = await api(`/api/search?q=${encodeURIComponent(query)}`);
+    const data = await res.json();
+    setResults(data);
+  };
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      {/* TODO: search overlay */}
+      <div className="bg-white p-4 rounded w-full max-w-lg">
+        <input
+          className="border p-2 w-full mb-2"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search..."
+        />
+        <div className="flex justify-end mb-2">
+          <button className="mr-2" onClick={onClose}>Close</button>
+          <button onClick={handleSearch}>Search</button>
+        </div>
+        {results && (
+          <div className="max-h-60 overflow-y-auto">
+            <h4 className="font-bold">Alerts</h4>
+            <ul>
+              {results.alerts.map((a) => (
+                <li key={a.id}>{a.title}</li>
+              ))}
+            </ul>
+            <h4 className="font-bold mt-2">Missions</h4>
+            <ul>
+              {results.missions.map((m) => (
+                <li key={m.id}>{m.title}</li>
+              ))}
+            </ul>
+            <h4 className="font-bold mt-2">Volunteers</h4>
+            <ul>
+              {results.volunteers.map((v) => (
+                <li key={v.id}>{v.firstName} {v.lastName}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/missions/MissionChat.jsx
+++ b/apps/web/src/components/missions/MissionChat.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+
+export default function MissionChat({ missionId }) {
+  const [socket, setSocket] = useState(null);
+  const [message, setMessage] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const s = io('/missions');
+    s.emit('join', missionId);
+    s.on('message', (msg) => setMessages((m) => [...m, msg]));
+    setSocket(s);
+    return () => s.disconnect();
+  }, [missionId]);
+
+  const sendMessage = () => {
+    if (socket && message) {
+      socket.emit('message', { missionId, message, user: 'Me' });
+      setMessage('');
+    }
+  };
+
+  return (
+    <div>
+      <div className="border h-40 overflow-y-auto mb-2 p-2">
+        {messages.map((m, idx) => (
+          <div key={idx}>{m.user}: {m.message}</div>
+        ))}
+      </div>
+      <div className="flex">
+        <input
+          className="border p-2 flex-grow"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Message"
+        />
+        <button className="ml-2" onClick={sendMessage}>Send</button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/missions/MissionDetail.jsx
+++ b/apps/web/src/components/missions/MissionDetail.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import MissionChat from './MissionChat';
 
 export default function MissionDetail({ missionId }) {
   return (
     <div className="container mx-auto py-8">
-      {/* TODO: fetch /missions/:missionId, assignment panel, resource tracker, chat notes */}
+      {/* TODO: fetch /missions/:missionId, assignment panel, resource tracker */}
+      <MissionChat missionId={missionId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- search module for API
- MissionGateway to handle chat sockets
- integrate new modules with AppModule
- implement GlobalSearchOverlay and mission chat components
- add socket.io deps

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f489ffe883238b941a06d6a77282