### PR TITLE
Add service worker push handler

### DIFF
--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,25 @@
+self.addEventListener('push', event => {
+  let data = {};
+  if (event.data) {
+    try {
+      data = event.data.json();
+    } catch (e) {
+      data = { title: event.data.text() };
+    }
+  }
+  const options = {
+    body: data.body || '',
+  };
+  if (data.url) {
+    options.data = { url: data.url };
+  }
+  event.waitUntil(self.registration.showNotification(data.title || 'Notification', options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = event.notification.data && event.notification.data.url;
+  if (url) {
+    event.waitUntil(clients.openWindow(url));
+  }
+});


### PR DESCRIPTION
## Summary
- add a `service-worker.js` in the web app
- include `data.url` when showing notifications
- open the notification URL on click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840fb927f7083239f6090b3ee22942d