### PR TITLE
Add theme color and favicon meta tags

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,10 @@ import './globals.css';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <meta name="theme-color" content="#1d4ed8" />
+        <link rel="icon" href="/icon-192.png" />
+      </head>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add theme color and favicon meta tags to the Web app layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840fb914a588323858982c41da082cb